### PR TITLE
Fix mixed settings descriptions

### DIFF
--- a/src/options/index.html
+++ b/src/options/index.html
@@ -40,8 +40,8 @@
         <p>Finished Investments</p>
         
         <table>
-            <tr id="InvestmentsShowProfitColumn"        ><td><input type="checkbox"></td><td><p>Show a loan duration column.                </p></td><td><p>example</p></td></tr>
-            <tr id="InvestmentsShowDurationColumn"      ><td><input type="checkbox"></td><td><p>Show a loan profit column.                  </p></td><td><p>example</p></td></tr>
+            <tr id="InvestmentsShowDurationColumn"      ><td><input type="checkbox"></td><td><p>Show a loan duration column.                </p></td><td><p>example</p></td></tr>
+            <tr id="InvestmentsShowProfitColumn"        ><td><input type="checkbox"></td><td><p>Show a loan profit column.                  </p></td><td><p>example</p></td></tr>
         </table>
         
         <p>Loan</p>


### PR DESCRIPTION
"Show a loan duration column" was tied to show profit column and vice versa.