### PR TITLE
Fix order of images on Finished Investments examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -25,8 +25,8 @@ chrome.storage.sync.get(
     'InvestmentsShowPremiumDiscount'    : true,
     
     // investmentsFinished.js
-    'InvestmentsShowProfitColumn'       : true,
     'InvestmentsShowDurationColumn'     : true,
+    'InvestmentsShowProfitColumn'       : true,
     
     // loan.js
     'LoanShowCountryRow'                : true,


### PR DESCRIPTION
Hi! 
First of all thanks for this extension! it's great 

Browsing through the examples I noticed that the images on the section Finished Investments were inverted. 
<img width="400" alt="Screenshot 2020-03-22 at 23 52 51" src="https://user-images.githubusercontent.com/4695692/77263792-60ea8600-6c99-11ea-84f9-d66f182e1428.png"><img width="400" alt="Screenshot 2020-03-22 at 23 53 21" src="https://user-images.githubusercontent.com/4695692/77263795-61831c80-6c99-11ea-97bd-b42d482108a5.png">

I'm not really familiar with extension development, but I think I managed to fix it. I tried it on Chrome and it's working correctly. 

Cheers : ) 

